### PR TITLE
Update rules.mk

### DIFF
--- a/utility/rules.mk
+++ b/utility/rules.mk
@@ -14,10 +14,10 @@ XCLBIN_DIR=xclbin
 #   $(1)_LDFLAGS - extra linkder flags
 define mk_exe
 
-$(1): $($(1)_SRCS) $($(1)_HDRS)
+$(1)_$(ARCH).exe: $($(1)_SRCS) $($(1)_HDRS)
 	$(CXX) $(CXXFLAGS) $($(1)_CXXFLAGS) -o $$@ $($(1)_SRCS) $($(1)_LDFLAGS) $(LDFLAGS)
 
-EXE_GOALS+= $(1)
+EXE_GOALS+= $(1)_$(ARCH).exe
 
 endef
 


### PR DESCRIPTION
This bug impacts every design in the SDAccel repository. The generated host executable file does not correspond to the rules explained in the design README files.
This impacts running designs in CPU Emu, HW Emu and HW deployment flows for ALL designs 