### PR TITLE
Fix AES implementation; code cleanup.

### DIFF
--- a/security/aes_decrypt/src/aes_ecb.h
+++ b/security/aes_decrypt/src/aes_ecb.h
@@ -1,5 +1,6 @@
 /**********
 Copyright (c) 2018, Xilinx, Inc.
+Copyright (c) 2018, Akamai Technologies, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
@@ -35,7 +36,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //Return value 
 // 0    Success
 //-1    Inputsize is not a multiple of 128 bit AES block size
-int aesecb_encrypt(unsigned char *key, unsigned char *input, unsigned char *output, size_t inputsize,const unsigned int rounds);
+int aesecb_encrypt(unsigned char *key, unsigned char *input, unsigned char *output, size_t inputsize, const unsigned int rounds);
 
 /////////////////////////////////////////////////////////////////////////////////
 //Electronic Code Book AES key expansion


### PR DESCRIPTION
The original implementation of the AES cipher assumed that the state matrix is
in row-major order, as C arrays are.  It is actually in column-major order, see:

  https://en.wikipedia.org/wiki/Advanced_Encryption_Standard#Description_of_the_cipher

Thus, all operations must operate on a transposed matrix: all steps that operate
on rows (i.e. ShiftRows) will need to operate on columns, and vice versa.  This
is implemented in both the encryption and decryption application.

Code cleanup was also done on the AES implementation, mostly in the form of the
addition of whitespace.  All C++ compilation warnings are resolved when using
the compilers provided with SDx.  The decrypt kernel code was modified slightly
in the Inverse MixColumns step to reduce the amount of code.  As it is written,
it should still have the same properties as the original implementation.

This was tested in the SDx software emulator on CentOS, and all tests passed.
Data rates when deployed KCU1500 card were approximately 3.25 GB/s.

This should fix #34 