### PR TITLE
Update Makefile

### DIFF
--- a/getting_started/host/helloworld_c/Makefile
+++ b/getting_started/host/helloworld_c/Makefile
@@ -28,7 +28,7 @@ CXXFLAGS = -I $(XILINX_SDX)/runtime/include/1_2/ -I/$(XILINX_SDX)/Vivado_HLS/inc
 LDFLAGS = -lOpenCL -lpthread -lrt -lstdc++ -L$(XILINX_SDX)/runtime/lib/x86_64
 
 # Kernel compiler global settings
-CLFLAGS = -t $(TARGET) --platform $(DEVICE) --save-temps 
+CLFLAGS += -t $(TARGET) --platform $(DEVICE) --save-temps 
 
 
 EXECUTABLE = host


### PR DESCRIPTION
I think 'CLFLAGS +=' should be used here otherwise the inputs to 'make' can not be picked up. The xocc command line will always be like: xocc -t -f --save--temps